### PR TITLE
fix duplicate items

### DIFF
--- a/src/helpers/menuHelper.js
+++ b/src/helpers/menuHelper.js
@@ -3,6 +3,13 @@ const getSelectedItem = (menuSections = [], id = '') => menuSections.reduce((acc
   return [...acc, ...filteredItem];
 }, []);
 
-const deleteSelectedItem = (selectedItems = [], id) => selectedItems.filter(selectedItem => selectedItem.id !== id)
+function deleteSelectedItem(selectedItems, id) {
+  for (var i = 0; i < selectedItems.length; i++)
+  if(selectedItems[i].id === id) {
+    selectedItems.splice(i, 1)
+    break;
+  }
+  return selectedItems;
+} 
 
 export { getSelectedItem, deleteSelectedItem }


### PR DESCRIPTION
**Bug**

If you had duplicate items in your cart, removing a single item would cause all items to be removed. 

1. Add 3 common burgers to your cart
2. Remove a common burger from your cart

Outcome: All common burgers will be removed 


This PR fixes the problem 